### PR TITLE
[FIX] Move VCR to test dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,10 @@ jobs:
           fingerprints:
             - $SSH_FINGERPRINT
       - checkout
+      - run:
+          name: update setuptools
+          command: |
+            poetry run pip install 'setuptools==71.0.0'
       - python/install-packages:
           pkg-manager: poetry
       - run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,9 @@ requests = "^2.32.2"
 asyncio = "^3.4.3"
 pydantic = "^2.4.2"
 openai = "^1.36.0"
-vcrpy = "^6.0.1"
 google-generativeai = "^0.7.2"
 cohere = "^5.6.1"
 nest-asyncio = "^1.6.0"
-
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.2.2"
@@ -33,11 +31,10 @@ pytest-asyncio = "^0.23.8"
 pytest-recording = "^0.13.2"
 pylint = "^3.2.5"
 mypy = "^1.11.0"
-
+vcrpy = "^6.0.1"
 
 [tool.poetry.group.pre-commit.dependencies]
 pre-commit = "^3.7.1"
-
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "martian-adapters"
-version = "5.19.0"
+version = "5.19.1"
 description = "Adapters as API gateways to Different LLM Models"
 authors = ["Martian team <team@withmartian.com>"]
 readme = "README.md"


### PR DESCRIPTION
vcrpy is used to store network requests during test. It is not used outside of tests, but due to https://github.com/kevin1024/vcrpy/issues/855, can cause installation of adapters to fail.

This PR moves vcrpy to the test dependencies.